### PR TITLE
Removing equal_to validation for input_type

### DIFF
--- a/resources/source.rb
+++ b/resources/source.rb
@@ -28,7 +28,7 @@ attribute :input_module, kind_of: String, default: 'im_file', required: true,
                                       im_mark im_mseventlog im_msvistalog
                                       im_null im_ssl im_tcp im_udp im_uds)
 attribute :destination, kind_of: [String, Array], default: :defaults
-attribute :input_type, kind_of: String, equal_to: %w(LineBased Dgram Binary)
+attribute :input_type, kind_of: String
 attribute :exec, kind_of: String
 attribute :flow_control, kind_of: [TrueClass, FalseClass]
 


### PR DESCRIPTION
The InputType directive can be an arbitrary string, and shouldn't be restricted to these three types. 

From the docs:

"Modules may provide custom input reader functions. Once these are registered into the nxlog core, the modules listed above will be capable of using these. This makes it easier to implement custom protocols because these can be developed without the need of taking care about the transport layer."

In practice, you'll see this most commonly implemented by using extensions like xm_multiline.

```
<Extension log4jmultiline>
  Module xm_multiline
  # We make two possibly dangerous assumptions here:
  # That all exceptions start with ".*threw exception:$" and end with
  # "^\s*at java.lang.Thread.run.*"
  HeaderLine /^.*threw exception$/
  EndLine /^\t*at java.lang.Thread.run.*/
</Extension>

<Input log4j>
  Module im_file
  InputType log4jmultiline
  File "/var/log/tomcat7/localhost*log"
  Exec $Message = $raw_event; to_json();
</Input>
```