### PR TITLE
Skip trying to install package mantainer's config when installing nxlog

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -51,7 +51,8 @@ end
 
 if platform?('ubuntu', 'debian')
   dpkg_package 'nxlog' do
-    source "#{Chef::Config[:file_cache_path]}/#{package_name}"
+    source "#{Chef::Config[:file_cache_path]}/#{package_name}" 
+    options "--force-confold"
   end
 else
   package 'nxlog' do


### PR DESCRIPTION
There's no real reason to install the config from the nxlog dpkg by default if a conflict occurs, as the nxlog cookbook will just overwrite it.

This unblocks convergence upon upgrading the package. Without this, the convergence step will fail as dpkg waits for interactive input on the conflicting configuration files. 