### PR TITLE
Changed :defaults to 'defaults' fixes #18

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -85,7 +85,7 @@ suites:
             mark: -> -> MARK <- <-
             destination:
               - test
-              - :defaults
+              - defaults
 
   - name: attribute_resources_windows
     run_list:
@@ -117,7 +117,7 @@ suites:
             mark: -> -> MARK <- <-
             destination:
               - test
-              - :defaults
+              - defaults
 
   - name: syslog
     run_list:

--- a/README.md
+++ b/README.md
@@ -229,21 +229,21 @@ end
 
 ##### Attributes common to all modules
 
-| Attribute name | Description                          | Type            | Default   |
-| -------------- | ------------------------------------ | --------------- | --------- |
-| input_module   | input module to use for the log data | String          | 'im_file' |
-| destination    | destination(s) to send the data to   | String or Array | :defaults |
-| input_type     | nxlog InputType (see nxlog docs)     | String          | none      |
-| exec           | commands to execute on the log data  | String          | none      |
-| flow_control   | enables or disables flow control     | Boolean         | false     |
+| Attribute name | Description                          | Type            | Default    |
+| -------------- | ------------------------------------ | --------------- | ---------  |
+| input_module   | input module to use for the log data | String          | 'im_file'  |
+| destination    | destination(s) to send the data to   | String or Array | 'defaults' |
+| input_type     | nxlog InputType (see nxlog docs)     | String          | none       |
+| exec           | commands to execute on the log data  | String          | none       |
+| flow_control   | enables or disables flow control     | Boolean         | false      |
 
 **Notes:**
 
 * input_module must be one of the modules defined below
 * to send log data to specific log destinations in addition to the defaults, 
-  include `:defaults` in the destination array. For example:
+  include `'defaults'` in the destination array. For example:
 ```ruby
-  destination ['my_special_destination', :defaults]
+  destination ['my_special_destination', 'defaults']
 ```
 * it is worth reading the documentation on `Exec` in the nxlog docs. Quite often
   log data needs to be transformed by a method such as `to_syslog_ietf()`
@@ -671,21 +671,21 @@ The attributes mostly concern default config locations and will most likely work
 for your platform without modification. 
 
 | Key                             | Description                                           | Default                                                                        |
-| ------------------------------- | ----------------------------------------------------- | ------------------------------------------------------------------------------ |
-| version                         | The version of nxlog_ce to download and install       | '2.9.1347'                                                                     |
-| log_level                       | nxlog's log level                                     | 'INFO'                                                                         |
-| user                            | The unix user to run nxlog as (no effect on Windows)  | 'nxlog'                                                                        |
-| group                           | The unix group to run nxlog as (no effect on Windows) | 'nxlog'                                                                        |
-| conf_dir                        | The directory for the nxlog configuration files       | platform-specific                                                              |
-| log_file                        | The location of the nxlog log file                    | platform-specific                                                              |
-| checksums::\<package_filename\> | The sha256sum of the specified package                | nxlog version-specific                                                         |
-| package_source                  | The base URL for downloading nxlog packages           | https://mirror.widgit.com/nxlog                                                |
-| papertrail::bundle_url          | The URL to the papertrail CA bundle                   | [papertrail-bundle.pem](https://papertrailapp.com/tools/papertrail-bundle.pem) |
-| syslog::logger_disable          | The logger service to disable in favour of nxlog      | 'rsyslog'                                                                      |
-| syslog::destinations            | The destinations to log syslog data to                | :defaults                                                                      |
-| sources                         | An array of log source objects                        | nil                                                                            |
-| destinations                    | An array of log destination objects                   | nil                                                                            |
-| papertrails                     | An array of papertrail log destination objects        | nil                                                                            |
+| ------------------------------- | ----------------------------------------------------- | ------------------------------------------------------------------------------- |
+| version                         | The version of nxlog_ce to download and install       | '2.9.1347'                                                                      |
+| log_level                       | nxlog's log level                                     | 'INFO'                                                                          |
+| user                            | The unix user to run nxlog as (no effect on Windows)  | 'nxlog'                                                                         |
+| group                           | The unix group to run nxlog as (no effect on Windows) | 'nxlog'                                                                         |
+| conf_dir                        | The directory for the nxlog configuration files       | platform-specific                                                               |
+| log_file                        | The location of the nxlog log file                    | platform-specific                                                               |
+| checksums::\<package_filename\> | The sha256sum of the specified package                | nxlog version-specific                                                          |
+| package_source                  | The base URL for downloading nxlog packages           | https://mirror.widgit.com/nxlog                                                 |
+| papertrail::bundle_url          | The URL to the papertrail CA bundle                   | [papertrail-bundle.pem](https://papertrailapp.com/tools/papertrail-bundle.pem)  |
+| syslog::logger_disable          | The logger service to disable in favour of nxlog      | 'rsyslog'                                                                       |
+| syslog::destinations            | The destinations to log syslog data to                | 'defaults'                                                                      |
+| sources                         | An array of log source objects                        | nil                                                                             |
+| destinations                    | An array of log destination objects                   | nil                                                                             |
+| papertrails                     | An array of papertrail log destination objects        | nil                                                                             |
 
 ## Contributing
 

--- a/attributes/syslog.rb
+++ b/attributes/syslog.rb
@@ -17,5 +17,5 @@
 # limitations under the License.
 #
 
-default['nxlog']['syslog']['destinations'] = :defaults
+default['nxlog']['syslog']['destinations'] = 'defaults'
 default['nxlog']['syslog']['logger_disable'] = 'rsyslog'

--- a/providers/source.rb
+++ b/providers/source.rb
@@ -127,7 +127,7 @@ action :create do
     end
 
     destinations = [*n.destination]
-    destinations.map! { |v| v == :defaults ? '%DEFAULT_OUTPUTS%' : v }
+    destinations.map! { |v| v == 'defaults' ? '%DEFAULT_OUTPUTS%' : v }
 
     # create template with above parameters
     template config_filename(n.name) do

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -73,8 +73,8 @@ end
 directory "#{node['nxlog']['conf_dir']}/nxlog.conf.d"
 
 # delete logging components that aren't converged as part of this chef run
-zap_directory "#{node['nxlog']['conf_dir']}/nxlog.conf.d" do
-  pattern '*.conf'
-end
+# zap_directory "#{node['nxlog']['conf_dir']}/nxlog.conf.d" do
+#   pattern '*.conf'
+# end
 
 include_recipe 'nxlog::resources_from_attributes'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -73,8 +73,8 @@ end
 directory "#{node['nxlog']['conf_dir']}/nxlog.conf.d"
 
 # delete logging components that aren't converged as part of this chef run
-# zap_directory "#{node['nxlog']['conf_dir']}/nxlog.conf.d" do
-#   pattern '*.conf'
-# end
+zap_directory "#{node['nxlog']['conf_dir']}/nxlog.conf.d" do
+  pattern '*.conf'
+end
 
 include_recipe 'nxlog::resources_from_attributes'

--- a/recipes/syslog.rb
+++ b/recipes/syslog.rb
@@ -31,7 +31,7 @@ service old_logger do
 end
 
 destinations = [node['nxlog']['syslog']['destinations']].flatten.map do |d|
-  d == ':defaults' ? :defaults : d
+  d == 'defaults' ? 'defaults' : d
 end
 
 bash 'remove_log_node' do

--- a/resources/destination.rb
+++ b/resources/destination.rb
@@ -64,7 +64,7 @@ attribute :https_allow_untrusted, kind_of: [TrueClass, FalseClass]
 
 # om_ssl, om_tcp, om_udp
 attribute :host, kind_of: String # required
-attribute :port, kind_of: Fixnum # required
+attribute :port, kind_of: Integer # required
 
 # om_ssl
 attribute :cert_file, kind_of: String
@@ -77,7 +77,7 @@ attribute :crl_dir, kind_of: String
 attribute :allow_untrusted, kind_of: [TrueClass, FalseClass]
 
 # om_udp
-attribute :sock_buf_size, kind_of: Fixnum
+attribute :sock_buf_size, kind_of: Integer
 
 # om_uds
 attribute :uds, kind_of: String, default: '/dev/log'

--- a/resources/source.rb
+++ b/resources/source.rb
@@ -51,7 +51,7 @@ attribute :rename_check, kind_of: [TrueClass, FalseClass]
 attribute :close_when_idle, kind_of: [TrueClass, FalseClass]
 attribute :poll_interval, kind_of: Float
 attribute :dir_check_interval, kind_of: Float
-attribute :active_files, kind_of: Fixnum
+attribute :active_files, kind_of: Integer
 
 # im_internal
 
@@ -59,7 +59,7 @@ attribute :active_files, kind_of: Fixnum
 
 # im_mark
 attribute :mark, kind_of: String
-attribute :mark_interval, kind_of: Fixnum
+attribute :mark_interval, kind_of: Integer
 
 # im_mseventlog
 attribute :sources, kind_of: Array
@@ -75,7 +75,7 @@ attribute :channel, kind_of: String
 
 # im_ssl, im_tcp, im_udp
 attribute :host, kind_of: String, default: 'localhost'
-attribute :port, kind_of: Fixnum # required
+attribute :port, kind_of: Integer # required
 
 # im_ssl
 attribute :cert_file, kind_of: String
@@ -88,7 +88,7 @@ attribute :crl_dir, kind_of: String
 attribute :allow_untrusted, kind_of: [TrueClass, FalseClass]
 
 # im_udp
-attribute :sock_buf_size, kind_of: Fixnum
+attribute :sock_buf_size, kind_of: Integer
 
 # im_uds
 attribute :uds, kind_of: String, default: '/dev/log'

--- a/resources/source.rb
+++ b/resources/source.rb
@@ -27,7 +27,7 @@ attribute :input_module, kind_of: String, default: 'im_file', required: true,
                          equal_to: %w(im_exec im_file im_internal im_kernel
                                       im_mark im_mseventlog im_msvistalog
                                       im_null im_ssl im_tcp im_udp im_uds)
-attribute :destination, kind_of: [String, Array], default: :defaults
+attribute :destination, kind_of: [String, Array], default: 'defaults'
 attribute :input_type, kind_of: String
 attribute :exec, kind_of: String
 attribute :flow_control, kind_of: [TrueClass, FalseClass]

--- a/spec/syslog_spec.rb
+++ b/spec/syslog_spec.rb
@@ -29,7 +29,7 @@ describe 'nxlog::syslog' do
       uds: '/var/run/nxlog/devlog',
       exec: 'parse_syslog_bsd();',
       flow_control: false,
-      destination: [:defaults]
+      destination: ['defaults']
     )
   end
 end

--- a/test/fixtures/cookbooks/test/recipes/default_resources.rb
+++ b/test/fixtures/cookbooks/test/recipes/default_resources.rb
@@ -53,5 +53,5 @@ end
 nxlog_source 'test_im_mark_4' do
   input_module 'im_mark'
   mark_interval 1
-  destination ['foo', 'bar', :defaults]
+  destination ['foo', 'bar', 'defaults']
 end

--- a/test/fixtures/cookbooks/test/recipes/default_resources.rb
+++ b/test/fixtures/cookbooks/test/recipes/default_resources.rb
@@ -53,5 +53,5 @@ end
 nxlog_source 'test_im_mark_4' do
   input_module 'im_mark'
   mark_interval 1
-  destination ['foo', 'bar', 'defaults']
+  destination %w(foo bar defaults)
 end

--- a/test/fixtures/cookbooks/test/recipes/default_resources_attrs.rb
+++ b/test/fixtures/cookbooks/test/recipes/default_resources_attrs.rb
@@ -52,7 +52,7 @@ node.override['nxlog'] = JSON.parse(<<EOT)
     "test_im_mark_4": {
       "input_module": "im_mark",
       "mark_interval": 1,
-      "destination": ["foo", "bar", ":defaults"]
+      "destination": ["foo", "bar", "defaults"]
     }
   }
 }


### PR DESCRIPTION
This changes the `:defaults` symbol for the `destination` to a `'defaults'` string. I wasn't sure if you wanted the API to work that way so feel free to reject this PR if you don't like it or if you have a better idea. I was able to get the Chefspec suite to pass but had some weird issues with running the Kitchen suite.